### PR TITLE
Upgrade project to .Net 6

### DIFF
--- a/TPMImport.csproj
+++ b/TPMImport.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
.Net 5 reached end of support on May 10, 2022 according to https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/ . It therefore probably makes sense to swich to the newer .Net 6 release.