### PR TITLE
CopyWithPersistedCngKeyFixed: Inline provider, keyName & dwKeySpec locals

### DIFF
--- a/DotNetCode/CertificateExtensionsCommon.cs
+++ b/DotNetCode/CertificateExtensionsCommon.cs
@@ -24,10 +24,8 @@ namespace DotNetCode
 				return null;
 			}
 			X509Certificate2 x509Certificate = new X509Certificate2(publicCert.RawData);
-			CngProvider provider = cngKey.Provider;
-			string keyName = cngKey.KeyName;
 			bool isMachineKey = IsMachineKey(cngKey);
-			int dwKeySpec = CertificateExtensionsCommon.GuessKeySpec(provider, keyName, isMachineKey, cngKey.AlgorithmGroup);
+			int dwKeySpec = CertificateExtensionsCommon.GuessKeySpec(cngKey.Provider, cngKey.KeyName, isMachineKey, cngKey.AlgorithmGroup);
 			X509Native.CRYPT_KEY_PROV_INFO crypt_KEY_PROV_INFO = default(X509Native.CRYPT_KEY_PROV_INFO);
 			crypt_KEY_PROV_INFO.pwszContainerName = cngKey.KeyName;
 			crypt_KEY_PROV_INFO.pwszProvName = cngKey.Provider.Provider;

--- a/DotNetCode/CertificateExtensionsCommon.cs
+++ b/DotNetCode/CertificateExtensionsCommon.cs
@@ -25,7 +25,6 @@ namespace DotNetCode
 			}
 			X509Certificate2 x509Certificate = new X509Certificate2(publicCert.RawData);
 			bool isMachineKey = IsMachineKey(cngKey);
-			int dwKeySpec = CertificateExtensionsCommon.GuessKeySpec(cngKey.Provider, cngKey.KeyName, isMachineKey, cngKey.AlgorithmGroup);
 			X509Native.CRYPT_KEY_PROV_INFO crypt_KEY_PROV_INFO = default(X509Native.CRYPT_KEY_PROV_INFO);
 			crypt_KEY_PROV_INFO.pwszContainerName = cngKey.KeyName;
 			crypt_KEY_PROV_INFO.pwszProvName = cngKey.Provider.Provider;
@@ -33,7 +32,7 @@ namespace DotNetCode
 			crypt_KEY_PROV_INFO.dwFlags = (int)(isMachineKey ? CngKeyOpenOptions.MachineKey : CngKeyOpenOptions.None);
 			crypt_KEY_PROV_INFO.cProvParam = 0;
 			crypt_KEY_PROV_INFO.rgProvParam = System.IntPtr.Zero;
-			crypt_KEY_PROV_INFO.dwKeySpec = dwKeySpec;
+			crypt_KEY_PROV_INFO.dwKeySpec = CertificateExtensionsCommon.GuessKeySpec(cngKey.Provider, cngKey.KeyName, isMachineKey, cngKey.AlgorithmGroup);
 			using (SafeCertContextHandle certificateContext = X509Native.GetCertificateContext(x509Certificate))
 			{
 				if (!X509Native.SetCertificateKeyProvInfo(certificateContext, ref crypt_KEY_PROV_INFO))


### PR DESCRIPTION
Done to simplify the impl. a bit, so that it's easier to understand. The variables in question can still be inspected in the debugger.

I've already verified that certificate import into TPM still works as before.