### PR TITLE
Get rid of intermediate XML representation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -104,9 +104,8 @@ namespace TPMImport
                 return;
             }
 
-            using RSACng keyFromPFx = new();
-            keyFromPFx.FromXmlString(cert.GetRSAPrivateKey().ToXmlString(true));
-            byte[] keyData = keyFromPFx.Key.Export(CngKeyBlobFormat.GenericPrivateBlob);
+            using var rsaPrivKey = (RSACng)cert.GetRSAPrivateKey();
+            byte[] keyData = rsaPrivKey.Key.Export(CngKeyBlobFormat.GenericPrivateBlob);
             CngKeyCreationParameters keyParams = new()
             {
                 ExportPolicy = CngExportPolicies.None,


### PR DESCRIPTION
I didn't quite see the point of exporting & importing the RSA private key into a new RSACng object here. Therefore, proposing to remove this intermediate step. Already tested locally with un-encrypted and encrypted PFX certificates generated with makecert.

The reason for fiddling with this code is that I'm experiencing problems importing certificates generated with New-SelfSignedCertificate into the TPM (registered as #10). This PR does unfortunately not fix that problem though.
