### PR TITLE
Modify CNG certificate object instead of creating a copy

### DIFF
--- a/DotNetCode/CertificateExtensionsCommon.cs
+++ b/DotNetCode/CertificateExtensionsCommon.cs
@@ -17,13 +17,13 @@ namespace DotNetCode
         }
 
         [SecurityCritical]
-        internal static X509Certificate2 CopyWithPersistedCngKeyFixed(X509Certificate2 publicCert, CngKey cngKey)
+        internal static void AddCngKey(X509Certificate2 x509Certificate, CngKey cngKey)
         {
             if (string.IsNullOrEmpty(cngKey.KeyName))
             {
-                return null;
+                x509Certificate.Dispose();
+                return;
             }
-            X509Certificate2 x509Certificate = new(publicCert.RawData);
             bool isMachineKey = IsMachineKey(cngKey);
             X509Native.CRYPT_KEY_PROV_INFO crypt_KEY_PROV_INFO = default;
             crypt_KEY_PROV_INFO.pwszContainerName = cngKey.KeyName;
@@ -40,7 +40,6 @@ namespace DotNetCode
                 x509Certificate.Dispose();
                 throw new CryptographicException(lastWin32Error);
             }
-            return x509Certificate;
         }
 
         private static int GuessKeySpec(CngProvider provider, string keyName, bool machineKey, CngAlgorithmGroup algorithmGroup)

--- a/DotNetCode/CertificateExtensionsCommon.cs
+++ b/DotNetCode/CertificateExtensionsCommon.cs
@@ -20,10 +20,9 @@ namespace DotNetCode
         internal static void AddCngKey(X509Certificate2 x509Certificate, CngKey cngKey)
         {
             if (string.IsNullOrEmpty(cngKey.KeyName))
-            {
-                x509Certificate.Dispose();
+
                 return;
-            }
+
             bool isMachineKey = IsMachineKey(cngKey);
             X509Native.CRYPT_KEY_PROV_INFO crypt_KEY_PROV_INFO = default;
             crypt_KEY_PROV_INFO.pwszContainerName = cngKey.KeyName;
@@ -37,7 +36,6 @@ namespace DotNetCode
             if (!X509Native.SetCertificateKeyProvInfo(certificateContext, ref crypt_KEY_PROV_INFO))
             {
                 int lastWin32Error = Marshal.GetLastWin32Error();
-                x509Certificate.Dispose();
                 throw new CryptographicException(lastWin32Error);
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -142,11 +142,11 @@ namespace TPMImport
                 Console.WriteLine($"Key is reported as Machine Key (always false): {key.IsMachineKey}; Key Is Closed: {key.Handle.IsClosed}; Is Invalid: {key.Handle.IsInvalid}; Export Policy: {key.ExportPolicy}; Is Ephemeral: {key.IsEphemeral}");
             }
 
-            using X509Certificate2 certOnly = new(cert.Export(X509ContentType.Cert));
-            using X509Certificate2 copiedCertificate = CertificateExtensionsCommon.CopyWithPersistedCngKeyFixed(certOnly, key);
+            using X509Certificate2 cngCert = new(cert.Export(X509ContentType.Cert));
+            CertificateExtensionsCommon.AddCngKey(cngCert, key);
 
             if (fVerbose)
-                using (RSACng keyOfCopiedCertificate = copiedCertificate.GetRSAPrivateKey() as RSACng)
+                using (RSACng keyOfCopiedCertificate = cngCert.GetRSAPrivateKey() as RSACng)
                 {
                     CngProperty NewExportPolicy = keyOfCopiedCertificate.Key.GetProperty("Export Policy", CngPropertyOptions.None);
                     string exportPolicyValue = string.Join('-',
@@ -158,9 +158,8 @@ namespace TPMImport
 
             using X509Store store = new(StoreName.My, fUser ? StoreLocation.CurrentUser : StoreLocation.LocalMachine);
             store.Open(OpenFlags.ReadWrite);
-            store.Add(copiedCertificate);
+            store.Add(cngCert);
             store.Close();
-
         }
     }
 }


### PR DESCRIPTION
Done to simplify the implementation a bit, since there will be fewer objects to deal with. Rename the `CopyWithPersistedCngKeyFixed` function to `AddCngKey` to better reflect the new behavior.