### PR TITLE
Add single-file x64 publishing profile

### DIFF
--- a/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0\publish\win-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Done to make it possible to build an almost self-contained EXE through the "publish" menu in Visual Studio. The EXE still depends on the .Net 6 runtime being installed on the system though.

It's also possible to embed the .Net runtime into the EXE to make it fully self-contained. However, that would increase the EXE size from 0.8MB to 15.3MB (after trimming unused code), which is kind of large for such a tool.