### PR TITLE
Fix broken IsMachineKey detection on Win11

### DIFF
--- a/DotNetCode/CertificateExtensionsCommon.cs
+++ b/DotNetCode/CertificateExtensionsCommon.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security;
 using System.Security.Cryptography;
@@ -11,6 +12,11 @@ namespace DotNetCode
     {
         public static bool IsMachineKey(CngKey cngKey)
         {
+            // the IsMachineKey property seem to be fixed on Win11
+            if (Environment.OSVersion.Version.Build >= 22000)
+                return cngKey.IsMachineKey;
+
+            // the following logic don't work on Win11 where GetProperty("Key Type"..) returns [32, 0, 0, 0] for LocalMachine keys
             CngProperty propMT = cngKey.GetProperty("Key Type", CngPropertyOptions.None);
             byte[] baMT = propMT.GetValue();
             return (baMT[0] & 1) == 1; // according to https://docs.microsoft.com/en-us/windows/win32/seccng/key-storage-property-identifiers, which defines NCRYPT_MACHINE_KEY_FLAG differently than ncrypt.h


### PR DESCRIPTION
Fixes #16. The `CngKey.IsMachineKey` property seem to work correctly when testing on Win11 (tested both in VM and on physical HW), whereas it always returns False on Win10.

The `GetProperty("Key Type"..)` behavior also seem to have changed for LocalMachine key storage, with it returning [1, 0, 0, 0] on Win10 and [32, 0, 0, 0] on Win11.

I've already tested the changes on a Win10 and a Win11 computer.