### PR TITLE
Restrict project to Windows platform

### DIFF
--- a/DotNetCode/CertificateExtensionsCommon.cs
+++ b/DotNetCode/CertificateExtensionsCommon.cs
@@ -7,7 +7,6 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace DotNetCode
 {
-    [SupportedOSPlatform("windows")]
     internal static class CertificateExtensionsCommon
     {
         public static bool IsMachineKey(CngKey cngKey)

--- a/Program.cs
+++ b/Program.cs
@@ -32,7 +32,6 @@ namespace TPMImport
         }
 
         /** Delete both the certificate & private key in TPM */
-        [SupportedOSPlatform("windows")]
         private static void DeleteCngCertificate(bool fUser, string Thumbprint)
         {
             using X509Store store = new X509Store(StoreName.My, fUser ? StoreLocation.CurrentUser : StoreLocation.LocalMachine);
@@ -64,7 +63,6 @@ namespace TPMImport
             }
         }
 
-        [SupportedOSPlatform("windows")]
         private static void Main(string[] args)
         {
             Console.WriteLine("PFX to TPM Importer");

--- a/TPMImport.csproj
+++ b/TPMImport.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Done to avoid the need to annotating functions with `[SupportedOSPlatform("windows")]` to avoid warnings. This project is inherently Windows-specific, so one can just as well make that clear in the project settings.