### PR TITLE
Upgrade .Net version from 6 to 8 (LTS)

### DIFF
--- a/TPMImport.csproj
+++ b/TPMImport.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Proposal to upgrade the project to building against the latest long-term support (LTS) version of .Net, which is 8.

The build still succeeds in both debug & release, without any new warnings as far as I can see.


.Net version overview: https://dotnet.microsoft.com/en-us/download/dotnet