### PR TITLE
[Work in Progress] new CngProvider change

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -143,7 +143,8 @@ namespace TPMImport
                 ExportPolicy = CngExportPolicies.None,
                 KeyCreationOptions = fUser ? CngKeyCreationOptions.None : CngKeyCreationOptions.MachineKey,
                 Provider =
-                new CngProvider("Microsoft Platform Crypto Provider"),
+                //new CngProvider("Microsoft Platform Crypto Provider"),
+                new CngProvider("Microsoft Smart Card Key Storage Provider"),
                 //CngProvider.MicrosoftSoftwareKeyStorageProvider
             };
             keyParams.Parameters.Add(new CngProperty(CngKeyBlobFormat.GenericPrivateBlob.Format, keyData, CngPropertyOptions.None));


### PR DESCRIPTION
I have changed this:
```
//new CngProvider("Microsoft Platform Crypto Provider"),
new CngProvider("Microsoft Smart Card Key Storage Provider"),
```

But shows:
```
PFX to TPM Importer
Creating RSA CngKeyObject with TPM-Import-Key-BC08045F11E2856FBAD27B70BEA6169B54712BF6
Unhandled exception. Internal.Cryptography.CryptoThrowHelper+WindowsCryptographicException: 密钥集不存在。
   at System.Security.Cryptography.CngKey.Create(CngAlgorithm algorithm, String keyName, CngKeyCreationParameters creationParameters)
   at TPMImport.Program.Main(String[] args) in D:\Downloads\TPMImport-main\TPMImport-main\Program.cs:line 167
```

Thank you :)