### PR TITLE
Add EC-DSA support

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -144,6 +144,7 @@ namespace TPMImport
                 return;
             }
 
+            CngAlgorithm algorithm = CngAlgorithm.Rsa;
             using var rsaPrivKey = (RSACng)cert.GetRSAPrivateKey();
             if (!rsaPrivKey.Key.ExportPolicy.HasFlag(CngExportPolicies.AllowPlaintextExport))
             {
@@ -173,14 +174,14 @@ namespace TPMImport
             //keyParams.Parameters.Add(new CngProperty("Security Descr", binSDL, (CngPropertyOptions) 0x44)); // 0x44 = DACL_SECURITY_INFORMATION | NCRYPT_SILENT_FLAG
 
             if (fVerbose)
-                Console.WriteLine($"Creating RSA CngKeyObject with TPM-Import-Key-{cert.Thumbprint}");
+                Console.WriteLine($"Creating CngKeyObject with TPM-Import-Key-{cert.Thumbprint}");
 
             CngKey key = null;
             string keyName = $"TPM-Import-Key-{cert.Thumbprint}";
 
             try
             {
-                key = CngKey.Create(CngAlgorithm.Rsa, keyName, keyParams);
+                key = CngKey.Create(algorithm, keyName, keyParams);
 
 
                 //            key = CngKey.Open($"TPM-Import-Key-{cert.Thumbprint}", new CngProvider("Microsoft Platform Crypto Provider"), CngKeyOpenOptions.MachineKey);

--- a/Program.cs
+++ b/Program.cs
@@ -174,6 +174,9 @@ namespace TPMImport
                     algorithm = CngAlgorithm.ECDsa;
                     keyData = ecdsaPrivKey.Key.Export(CngKeyBlobFormat.GenericPrivateBlob);
                 }
+
+                if (algorithm == default(CngAlgorithm))
+                    throw new ArgumentException("Unsuported certificate type");
             }
 
             CngKeyCreationParameters keyParams = new()


### PR DESCRIPTION
Fixes #14. According to https://en.wikipedia.org/wiki/Trusted_Platform_Module then TPM 2.0 chips are required to also support "ECC using the NIST P-256 curve" in addition to RSA. It then makes sense to extend TPMImport to also support this crypto algorithm.

Attempting to import a EC-DSA certificate to the TPM using `certutil` leads to an `NTE_BAD_TYPE` error.

## Test instructions
#### PowerShell script to generate a EC-DSA certificate for testing
```
# Generate ECC NIST P-256 certificate
# The enhanced key usage (EKU) OID for clientAuth is 1.3.6.1.5.5.7.3.2
# The enhanced key usage (EKU) OID for codeSigning is 1.3.6.1.5.5.7.3.3
$client = New-SelfSignedCertificate -CertStoreLocation "Cert:\CurrentUser\My" -Type Custom -Subject "CN=ClientCert" -KeyUsageProperty All -KeyUsage None -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.2,1.3.6.1.5.5.7.3.3") -KeyExportPolicy Exportable -KeyAlgorithm ECDSA_nistP256 -CurveExport 'CurveName'

# PFX password (haven't figured out how to avoid it)
$pwd = ConvertTo-SecureString -String "1234" -AsPlainText -Force
Export-PfxCertificate -Cert $client -Password $pwd -FilePath "ECDsaCert.pfx"
```

#### Import EC-DSA certificate into TMP
```
>TPMImport.exe -v ECDsaCert.pfx 1234
PFX to TPM Importer
Creating CngKeyObject with TPM-Import-Key-E65E83F648D85FC984849FA805DCE7DEB52E34EE
Key is reported as Machine Key (always false): True; Key Is Closed: False; Is Invalid: False; Export Policy: None; Is Ephemeral: False
Export Policy of copied key: 3-0-0-0
```

#### Verify that certificate is stored in TPM
```
>certutil -csp TPM -key
Microsoft Platform Crypto Provider:
  TPM-Import-Key-E65E83F648D85FC984849FA805DCE7DEB52E34EE
  C:\ProgramData\Microsoft\Crypto\PCPKSP\1013cb1a9ec8a4be89428d0b9286606dcd98e1cf\03d237000021ee928a17d7a183e0785bf429b568.PCPKEY
  ECDSA
  nistP256


CertUtil: -key command completed successfully.
```
