### PR TITLE
Document valid CRYPT_KEY_PROV_INFO.dwKeySpec values

### DIFF
--- a/DotNetCode/X509Native.cs
+++ b/DotNetCode/X509Native.cs
@@ -74,7 +74,7 @@ namespace DotNetCode
             // Token: 0x04000F7B RID: 3963
             internal IntPtr rgProvParam;
 
-            // Token: 0x04000F7C RID: 3964
+            // Token: 0x04000F7C RID: 3964 (AT_KEYEXCHANGE=1, AT_SIGNATURE=2)
             internal int dwKeySpec;
         }
 


### PR DESCRIPTION
Based on https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crypt_key_prov_info with underlying values from `<wincrypt.h>`.

`<wincrypt.h>` extract:  
![image](https://github.com/user-attachments/assets/d8249ab6-7f58-47bf-950a-f93c42aad914)
